### PR TITLE
Update to repair RPi1, RPi2, and RPi3 boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,19 @@ Raspberry.System provides utilities for Raspberry Pi boards, while using .NET co
 You can easily add a reference to it in your Visual Studio projects using the **[Raspberry.System Nuget](https://www.nuget.org/packages/Raspberry.System)**.
 
 It currently support the following features:
-+ Automatic detection of various Raspberry Pi revisions, as of 2013-09, **Raspberry Pi model B rev1 and rev2 and Raspberry Pi model A**
-+ High resolution (about 1µs) timers
++ Automatic detection of various Raspberry Pi revisions, as of December 2020, **Raspberry Pi model 1 through 4 hardware (including compute modules and zero)**
++ High resolution (about 1Âµs) timers
+
+
+Compile
+-------
++ Clone the code to your system
+  sudo git clone https://github.com/bkenobi/raspberry-sharp-system.git
++ change owner/group to pi (or whatever you log on as)
+  sudo chown -R pi <development directory>;  sudo chgrp -R pi <development directory>
++ install mono-devel
+  sudo apt install mono-devel
++ Compile Test.Board
+  msbuild Test.Board.csproj
++ run Test.Board.exe to confirm the code runs
+  mono Test.Board.exe

--- a/README.md
+++ b/README.md
@@ -24,13 +24,8 @@ It currently support the following features:
 
 Compile
 -------
-+ Clone the code to your system
-  sudo git clone https://github.com/bkenobi/raspberry-sharp-system.git
-+ change owner/group to pi (or whatever you log on as)
-  sudo chown -R pi <development directory>;  sudo chgrp -R pi <development directory>
-+ install mono-devel
-  sudo apt install mono-devel
-+ Compile Test.Board
-  msbuild Test.Board.csproj
-+ run Test.Board.exe to confirm the code runs
-  mono Test.Board.exe
++ Clone the code to your system:  sudo git clone https://github.com/bkenobi/raspberry-sharp-system.git
++ change owner/group to pi (or whatever you log on as):  sudo chown -R pi **development directory**;  sudo chgrp -R pi **development directory**
++ install mono-devel:  sudo apt install mono-devel
++ Compile Test.Board:  msbuild Test.Board.csproj
++ run Test.Board.exe to confirm the code runs:  mono Test.Board.exe

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -91,8 +91,8 @@ namespace Raspberry
             get
             {
                 Processor processor;
-                if (Enum.TryParse(ProcessorName, true, out processor))
-                {
+                ///if (Enum.TryParse(ProcessorName, true, out processor))
+                ///{
                     // Model usually lies and reports BCM2835
                     switch (Model)
                     {
@@ -123,7 +123,7 @@ namespace Raspberry
                             processor = Processor.Unknown
                             return processor;
                     }
-                }
+                ///}
             }
         }
 

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -114,8 +114,21 @@ namespace Raspberry
                         processor = Processor.Bcm2835;
                         return processor;
 
+                    case Model.B2:
+                        processor = Processor.Bcm2836
+                        return processor;
+
+                    case Model.B3:
+                    case Model.ComputeModule3:
+                        processor = Processor.Bcm2837
+                        return processor;
+
+                    case Model.Pi4:
+                        processor = Processor.Bcm2711;
+                        return processor;
+
                     default:
-                        processor = Processor.Unknown;
+                        processor = Processor.Unknown
                         return processor;
                 }
 

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -44,7 +44,7 @@ namespace Raspberry
         /// </summary>
         public static Board Current
         {
-            Console.WriteLine("Inside  Boards.cs Board Current");
+            ///Console.WriteLine("Inside  Boards.cs Board Current");
             get { return board.Value; }
         }
 
@@ -56,7 +56,7 @@ namespace Raspberry
         /// </value>
         public bool IsRaspberryPi
         {
-            Console.WriteLine("Inside  Boards.cs IsRaspberryPi");
+            ///Console.WriteLine("Inside  Boards.cs IsRaspberryPi");
             get
             {
                 return Processor != Processor.Unknown;
@@ -71,7 +71,7 @@ namespace Raspberry
         /// </value>
         public string ProcessorName
         {
-            Console.WriteLine("Inside  Boards.cs ProcessorName");
+            ///Console.WriteLine("Inside  Boards.cs ProcessorName");
             get
             {
                 string hardware;
@@ -87,7 +87,7 @@ namespace Raspberry
         /// </value>
         public Processor Processor
         {
-            Console.WriteLine("Inside  Boards.cs Processor");
+            ///Console.WriteLine("Inside  Boards.cs Processor");
             get
             {
                 Processor processor;
@@ -113,7 +113,7 @@ namespace Raspberry
         /// </summary>
         public int Firmware
         {
-            Console.WriteLine("Inside  Boards.cs Firmware");
+            ///Console.WriteLine("Inside  Boards.cs Firmware");
             get
             {
                 string revision;
@@ -132,7 +132,7 @@ namespace Raspberry
         /// </summary>
         public string SerialNumber
         {
-            Console.WriteLine("Inside  Boards.cs SerialNumber");
+            ///Console.WriteLine("Inside  Boards.cs SerialNumber");
             get {
                 string serial;
                 if (settings.TryGetValue("Serial", out serial)
@@ -151,7 +151,7 @@ namespace Raspberry
         /// </value>
         public bool IsOverclocked
         {
-            Console.WriteLine("Inside  Boards.cs IsOverclocked");
+            ///Console.WriteLine("Inside  Boards.cs IsOverclocked");
             get
             {
                 var firmware = Firmware;
@@ -167,7 +167,7 @@ namespace Raspberry
         /// </value>
         public Model Model
         {
-            Console.WriteLine("Inside  Boards.cs Model");
+            ///Console.WriteLine("Inside  Boards.cs Model");
             get { return model.Value; }
         }
 
@@ -180,7 +180,7 @@ namespace Raspberry
         /// <remarks>See <see cref="http://raspi.tv/2014/rpi-gpio-quick-reference-updated-for-raspberry-pi-b"/> for more information.</remarks>
         public ConnectorPinout ConnectorPinout
         {
-            Console.WriteLine("Inside  Boards.cs ConnectorPinout");
+            ///Console.WriteLine("Inside  Boards.cs ConnectorPinout");
             get { return connectorPinout.Value; }
         }
 
@@ -190,7 +190,7 @@ namespace Raspberry
 
         private static Board LoadBoard()
         {
-            Console.WriteLine("Inside  Boards.cs Board LoadBoard");
+            ///Console.WriteLine("Inside  Boards.cs Board LoadBoard");
             try
             {
                 const string filePath = "/proc/cpuinfo";
@@ -227,7 +227,7 @@ namespace Raspberry
 
         private Model LoadModel()
         {
-            Console.WriteLine("Inside  Boards.cs Model LoadModel");
+            ///Console.WriteLine("Inside  Boards.cs Model LoadModel");
             var firmware = Firmware;
             Console.WriteLine("Firmware = {0:x}", firmware);
             Console.WriteLine("Firmware & 0xFFFF = {0:x}", firmware & 0xFFFF);
@@ -297,7 +297,7 @@ namespace Raspberry
 
         private ConnectorPinout LoadConnectorPinout()
         {
-            Console.WriteLine("Inside  Boards.cs ConnectorPinout LoadConnectorPinout");
+            ///Console.WriteLine("Inside  Boards.cs ConnectorPinout LoadConnectorPinout");
             switch (Model)
             {
                 case Model.BRev1:

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -226,7 +226,8 @@ namespace Raspberry
                 return new Board(new Dictionary<string, string>());
             }
         }
-
+        
+        /// HW revision derived from: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
         private Model LoadModel()
         {
             var firmware = Firmware;
@@ -269,8 +270,12 @@ namespace Raspberry
                     return Model.Zero;
 
                 case 0x2082:
+                case 0x2083:
+                case 0x20D3: ///3A+ and 3B+
                     return Model.B3;
+                    
                 case 0x20A0:
+                case 0x2100: ///CM3+
                     return Model.ComputeModule3;
 
                 case 0x03111:

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -128,7 +128,7 @@ namespace Raspberry
                         return processor;
 
                     default:
-                        processor = Processor.Unknown
+                        processor = Processor.Unknown;
                         return processor;
                 }
 

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -115,12 +115,12 @@ namespace Raspberry
                         return processor;
 
                     case Model.B2:
-                        processor = Processor.Bcm2836
+                        processor = Processor.Bcm2836;
                         return processor;
 
                     case Model.B3:
                     case Model.ComputeModule3:
-                        processor = Processor.Bcm2837
+                        processor = Processor.Bcm2837;
                         return processor;
 
                     case Model.Pi4:

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -32,7 +32,6 @@ namespace Raspberry
             model = new Lazy<Model>(LoadModel);
             connectorPinout = new Lazy<ConnectorPinout>(LoadConnectorPinout);
             this.settings = settings;
-            Console.WriteLine("connectorPinout = " + connectorPinout);
         }
 
         #endregion
@@ -44,7 +43,6 @@ namespace Raspberry
         /// </summary>
         public static Board Current
         {
-            ///Console.WriteLine("Inside  Boards.cs Board Current");
             get { return board.Value; }
         }
 
@@ -56,7 +54,6 @@ namespace Raspberry
         /// </value>
         public bool IsRaspberryPi
         {
-            ///Console.WriteLine("Inside  Boards.cs IsRaspberryPi");
             get
             {
                 return Processor != Processor.Unknown;
@@ -71,7 +68,6 @@ namespace Raspberry
         /// </value>
         public string ProcessorName
         {
-            ///Console.WriteLine("Inside  Boards.cs ProcessorName");
             get
             {
                 string hardware;
@@ -87,21 +83,9 @@ namespace Raspberry
         /// </value>
         public Processor Processor
         {
-            ///Console.WriteLine("Inside  Boards.cs Processor");
             get
             {
                 Processor processor;
-                //if (Enum.TryParse(ProcessorName, true, out processor))
-                //{
-                //    // Check to see if we're dealing with a Pi 4 Model B
-                //    // The Pi 4 Model B currently lies to us and tells us that it's a BCM2835
-                //    if (processor == Processor.Bcm2835 && Model == Model.Pi4)
-                //    {
-                //        processor = Processor.Bcm2711;
-                //    }
-                //    return processor;
-                //}
-
                 switch (Model)
                 {
                     case Model.A:
@@ -138,7 +122,6 @@ namespace Raspberry
         /// </summary>
         public int Firmware
         {
-            ///Console.WriteLine("Inside  Boards.cs Firmware");
             get
             {
                 string revision;
@@ -157,7 +140,6 @@ namespace Raspberry
         /// </summary>
         public string SerialNumber
         {
-            ///Console.WriteLine("Inside  Boards.cs SerialNumber");
             get {
                 string serial;
                 if (settings.TryGetValue("Serial", out serial)
@@ -176,7 +158,6 @@ namespace Raspberry
         /// </value>
         public bool IsOverclocked
         {
-            ///Console.WriteLine("Inside  Boards.cs IsOverclocked");
             get
             {
                 var firmware = Firmware;
@@ -192,7 +173,6 @@ namespace Raspberry
         /// </value>
         public Model Model
         {
-            ///Console.WriteLine("Inside  Boards.cs Model");
             get { return model.Value; }
         }
 
@@ -205,7 +185,6 @@ namespace Raspberry
         /// <remarks>See <see cref="http://raspi.tv/2014/rpi-gpio-quick-reference-updated-for-raspberry-pi-b"/> for more information.</remarks>
         public ConnectorPinout ConnectorPinout
         {
-            ///Console.WriteLine("Inside  Boards.cs ConnectorPinout");
             get { return connectorPinout.Value; }
         }
 
@@ -215,7 +194,6 @@ namespace Raspberry
 
         private static Board LoadBoard()
         {
-            ///Console.WriteLine("Inside  Boards.cs Board LoadBoard");
             try
             {
                 const string filePath = "/proc/cpuinfo";
@@ -236,7 +214,6 @@ namespace Raspberry
                             suffix = "." + val;
 
                         settings.Add(key + suffix, val);
-                        ///Console.WriteLine("setting.add = " + key + " + " + suffix + ", " + val);
                     }
                     else
                         suffix = "";
@@ -252,16 +229,12 @@ namespace Raspberry
 
         private Model LoadModel()
         {
-            ///Console.WriteLine("Inside  Boards.cs Model LoadModel");
             var firmware = Firmware;
-            Console.WriteLine("Firmware = {0:x}", firmware);
-            Console.WriteLine("Firmware & 0xFFFF = {0:x}", firmware & 0xFFFF);
             
             switch (firmware & 0xFFFF)
             {
                 case 0x2:
                 case 0x3:
-                    Console.WriteLine("Model.BRev1");
                     return Model.BRev1;
 
                 case 0x4:
@@ -270,69 +243,55 @@ namespace Raspberry
                 case 0xd:
                 case 0xe:
                 case 0xf:
-                    Console.WriteLine("Model.BRev2");
                     return Model.BRev2;
 
                 case 0x7:
                 case 0x8:
                 case 0x9:
-                    Console.WriteLine("Model.A");
                     return Model.A;
 
                 case 0x10:
-                    Console.WriteLine("Model.BPlus1");
                     return Model.BPlus;
 
                 case 0x11:
-                    Console.WriteLine("Model.ComputeModule");
                     return Model.ComputeModule;
 
                 case 0x12:
-                    Console.WriteLine("Model.APlus");
                     return Model.APlus;
 
                 case 0x1040:
                 case 0x1041:
-                    Console.WriteLine("Model.B2");
                     return Model.B2;
 
                 case 0x0092:
                 case 0x0093:
                 case 0x00C1:
-                    Console.WriteLine("Model.Zero");
                     return Model.Zero;
 
                 case 0x2082:
-                    Console.WriteLine("Model.B3");
                     return Model.B3;
                 case 0x20A0:
-                    Console.WriteLine("Model.ComputeModule3");
                     return Model.ComputeModule3;
 
                 case 0x03111:
                 case 0x03112:
                 case 0x03114:
-                    Console.WriteLine("Model.Pi4");
                     return Model.Pi4;
 
                 default:
-                    Console.WriteLine("Model.Unknown");
                     return Model.Unknown;
             }
         }
 
         private ConnectorPinout LoadConnectorPinout()
         {
-            ///Console.WriteLine("Inside  Boards.cs ConnectorPinout LoadConnectorPinout");
             switch (Model)
             {
                 case Model.BRev1:
-                    Console.WriteLine("ConnectorPinout.Rev1");
                     return ConnectorPinout.Rev1;
 
                 case Model.BRev2:
                 case Model.A:
-                    Console.WriteLine("ConnectorPinout.Rev2");
                     return ConnectorPinout.Rev2;
 
                 case Model.BPlus:
@@ -343,11 +302,9 @@ namespace Raspberry
                 case Model.B3:
                 case Model.ComputeModule3:
                 case Model.Pi4:
-                    Console.WriteLine("ConnectorPinout.Plus");
                     return ConnectorPinout.Plus;
 
                 default:
-                    Console.WriteLine("ConnectorPinout.Unknown");
                     return ConnectorPinout.Unknown;
             }
         }

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -91,11 +91,12 @@ namespace Raspberry
             get
             {
                 Processor processor;
-                ///if (Enum.TryParse(ProcessorName, true, out processor))
-                ///{
+                if (Enum.TryParse(ProcessorName, true, out processor))
+                {
                     // Model usually lies and reports BCM2835
                     switch (Model)
                     {
+                        /*
                         case Model.A:
                         case Model.APlus:
                         case Model.BRev1:
@@ -105,11 +106,11 @@ namespace Raspberry
                         case Model.Zero:
                             processor = Processor.Bcm2835;
                             return processor;
-                            
+                        */    
                         case Model.B2:
                             processor = Processor.Bcm2836
                             return processor;
-                            
+                        /*  
                         case Model.B3:
                         case Model.ComputeModule3:
                             processor = Processor.Bcm2837
@@ -118,12 +119,12 @@ namespace Raspberry
                         case Model.Pi4:
                             processor = Processor.Bcm2711;
                             return processor;
-                            
+                        */    
                         case default:
                             processor = Processor.Unknown
                             return processor;
                     }
-                ///}
+                }
             }
         }
 

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -32,6 +32,7 @@ namespace Raspberry
             model = new Lazy<Model>(LoadModel);
             connectorPinout = new Lazy<ConnectorPinout>(LoadConnectorPinout);
             this.settings = settings;
+            Console.WriteLine("connectorPinout = " + connectorPinout);
         }
 
         #endregion

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -91,18 +91,35 @@ namespace Raspberry
             get
             {
                 Processor processor;
-                if (Enum.TryParse(ProcessorName, true, out processor))
+                //if (Enum.TryParse(ProcessorName, true, out processor))
+                //{
+                //    // Check to see if we're dealing with a Pi 4 Model B
+                //    // The Pi 4 Model B currently lies to us and tells us that it's a BCM2835
+                //    if (processor == Processor.Bcm2835 && Model == Model.Pi4)
+                //    {
+                //        processor = Processor.Bcm2711;
+                //    }
+                //    return processor;
+                //}
+
+                switch (Model)
                 {
-                    // Check to see if we're dealing with a Pi 4 Model B
-                    // The Pi 4 Model B currently lies to us and tells us that it's a BCM2835
-                    if (processor == Processor.Bcm2835 && Model == Model.Pi4)
-                    {
-                        processor = Processor.Bcm2711;
-                    }
-                    return processor;
+                    case Model.A:
+                    case Model.APlus:
+                    case Model.BRev1:
+                    case Model.BRev2:
+                    case Model.BPlus:
+                    case Model.ComputeModule:
+                    case Model.Zero:
+                        processor = Processor.Bcm2835;
+                        return processor;
+
+                    default:
+                        processor = Processor.Unknown;
+                        return processor;
                 }
 
-                return  Processor.Unknown;
+                return Processor.Unknown;
             }
         }
 

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -93,10 +93,18 @@ namespace Raspberry
                 Processor processor;
                 if (Enum.TryParse(ProcessorName, true, out processor))
                 {
+                    switch (Model)
+                    {
+                        case Model.B2:
+                            Console.WriteLine("Model.B2 = Bcm2836");
+                        case default:
+                            Console.Writeline("unknown");
+                    }
+                    /*
                     // Model usually lies and reports BCM2835
                     switch (Model)
                     {
-                        /*
+                        
                         case Model.A:
                         case Model.APlus:
                         case Model.BRev1:
@@ -106,11 +114,11 @@ namespace Raspberry
                         case Model.Zero:
                             processor = Processor.Bcm2835;
                             return processor;
-                        */    
+                            
                         case Model.B2:
                             processor = Processor.Bcm2836
                             return processor;
-                        /*  
+                          
                         case Model.B3:
                         case Model.ComputeModule3:
                             processor = Processor.Bcm2837
@@ -119,11 +127,12 @@ namespace Raspberry
                         case Model.Pi4:
                             processor = Processor.Bcm2711;
                             return processor;
-                        */    
+                            
                         case default:
                             processor = Processor.Unknown
                             return processor;
                     }
+                    */
                 }
             }
         }

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -93,47 +93,16 @@ namespace Raspberry
                 Processor processor;
                 if (Enum.TryParse(ProcessorName, true, out processor))
                 {
-                    switch (Model)
+                    // Check to see if we're dealing with a Pi 4 Model B
+                    // The Pi 4 Model B currently lies to us and tells us that it's a BCM2835
+                    if (processor == Processor.Bcm2835 && Model == Model.Pi4)
                     {
-                        case Model.B2:
-                            Console.WriteLine("Model.B2 = Bcm2836");
-                        case default:
-                            Console.Writeline("unknown");
+                        processor = Processor.Bcm2711;
                     }
-                    /*
-                    // Model usually lies and reports BCM2835
-                    switch (Model)
-                    {
-                        
-                        case Model.A:
-                        case Model.APlus:
-                        case Model.BRev1:
-                        case Model.BRev2:
-                        case Model.BPlus:
-                        case Model.ComputeModule:
-                        case Model.Zero:
-                            processor = Processor.Bcm2835;
-                            return processor;
-                            
-                        case Model.B2:
-                            processor = Processor.Bcm2836
-                            return processor;
-                          
-                        case Model.B3:
-                        case Model.ComputeModule3:
-                            processor = Processor.Bcm2837
-                            return processor;
-                            
-                        case Model.Pi4:
-                            processor = Processor.Bcm2711;
-                            return processor;
-                            
-                        case default:
-                            processor = Processor.Unknown
-                            return processor;
-                    }
-                    */
+                    return processor;
                 }
+
+                return  Processor.Unknown;
             }
         }
 

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -218,8 +218,8 @@ namespace Raspberry
         private Model LoadModel()
         {
             var firmware = Firmware;
-            Console.WriteLine("Firmware = " + firmware);
-            ///Console.WriteLine("Firmware & 0xFFFF = " + firmware & 0xFFFF);
+            Console.WriteLine("Firmware = {0:x}", firmware);
+            Console.WriteLine("Firmware & 0xFFFF = {0:x}", firmware & 0xFFFF);
             
             switch (firmware & 0xFFFF)
             {

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -219,7 +219,7 @@ namespace Raspberry
         {
             var firmware = Firmware;
             Console.WriteLine("Firmware = " + firmware);
-            Console.WriteLine("Firmware & 0xFFFF = " + firmware & 0xFFFF);
+            ///Console.WriteLine("Firmware & 0xFFFF = " + firmware & 0xFFFF);
             
             switch (firmware & 0xFFFF)
             {

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -111,16 +111,13 @@ namespace Raspberry
                     case Model.BPlus:
                     case Model.ComputeModule:
                     case Model.Zero:
-                        processor = Processor.Bcm2835;
+                        processor = Processor.Bcm2708;
                         return processor;
 
                     case Model.B2:
-                        processor = Processor.Bcm2836;
-                        return processor;
-
                     case Model.B3:
                     case Model.ComputeModule3:
-                        processor = Processor.Bcm2837;
+                        processor = Processor.Bcm2709;
                         return processor;
 
                     case Model.Pi4:
@@ -301,6 +298,7 @@ namespace Raspberry
 
                 case 0x0092:
                 case 0x0093:
+                case 0x00C1:
                     Console.WriteLine("Model.Zero");
                     return Model.Zero;
 

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -93,18 +93,37 @@ namespace Raspberry
                 Processor processor;
                 if (Enum.TryParse(ProcessorName, true, out processor))
                 {
-                    // Check to see if we're dealing with a Pi 4 Model B
-                    // The Pi 4 Model B currently lies to us and tells us that it's a BCM2835
-                    if (processor == Processor.Bcm2835 && Model == Model.Pi4)
+                    // Model usually lies and reports BCM2835
+                    switch (Model)
                     {
-                        processor = Processor.Bcm2711;
+                        case Model.A:
+                        case Model.APlus:
+                        case Model.BRev1:
+                        case Model.BRev2:
+                        case Model.BPlus:
+                        case Model.ComputeModule:
+                        case Model.Zero:
+                            processor = Processor.Bcm2835;
+                            return processor;
+                            
+                        case Model.B2:
+                            processor = Processor.Bcm2836
+                            return processor;
+                            
+                        case Model.B3:
+                        case Model.ComputeModule3:
+                            processor = Processor.Bcm2837
+                            return processor;
+                            
+                        case Model.Pi4:
+                            processor = Processor.Bcm2711;
+                            return processor;
+                            
+                        case default:
+                            processor = Processor.Unknown
+                            return processor;
                     }
-                    Console.WriteLine(processor);
-                    return processor;
                 }
-
-                Console.WriteLine("Processor.Unknown");
-                return  Processor.Unknown;
             }
         }
 

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -44,6 +44,7 @@ namespace Raspberry
         /// </summary>
         public static Board Current
         {
+            Console.WriteLine("Inside  Boards.cs Board Current");
             get { return board.Value; }
         }
 
@@ -55,6 +56,7 @@ namespace Raspberry
         /// </value>
         public bool IsRaspberryPi
         {
+            Console.WriteLine("Inside  Boards.cs IsRaspberryPi");
             get
             {
                 return Processor != Processor.Unknown;
@@ -69,6 +71,7 @@ namespace Raspberry
         /// </value>
         public string ProcessorName
         {
+            Console.WriteLine("Inside  Boards.cs ProcessorName");
             get
             {
                 string hardware;
@@ -84,6 +87,7 @@ namespace Raspberry
         /// </value>
         public Processor Processor
         {
+            Console.WriteLine("Inside  Boards.cs Processor");
             get
             {
                 Processor processor;
@@ -109,6 +113,7 @@ namespace Raspberry
         /// </summary>
         public int Firmware
         {
+            Console.WriteLine("Inside  Boards.cs Firmware");
             get
             {
                 string revision;
@@ -127,6 +132,7 @@ namespace Raspberry
         /// </summary>
         public string SerialNumber
         {
+            Console.WriteLine("Inside  Boards.cs SerialNumber");
             get {
                 string serial;
                 if (settings.TryGetValue("Serial", out serial)
@@ -145,6 +151,7 @@ namespace Raspberry
         /// </value>
         public bool IsOverclocked
         {
+            Console.WriteLine("Inside  Boards.cs IsOverclocked");
             get
             {
                 var firmware = Firmware;
@@ -160,6 +167,7 @@ namespace Raspberry
         /// </value>
         public Model Model
         {
+            Console.WriteLine("Inside  Boards.cs Model");
             get { return model.Value; }
         }
 
@@ -172,6 +180,7 @@ namespace Raspberry
         /// <remarks>See <see cref="http://raspi.tv/2014/rpi-gpio-quick-reference-updated-for-raspberry-pi-b"/> for more information.</remarks>
         public ConnectorPinout ConnectorPinout
         {
+            Console.WriteLine("Inside  Boards.cs ConnectorPinout");
             get { return connectorPinout.Value; }
         }
 
@@ -181,6 +190,7 @@ namespace Raspberry
 
         private static Board LoadBoard()
         {
+            Console.WriteLine("Inside  Boards.cs Board LoadBoard");
             try
             {
                 const string filePath = "/proc/cpuinfo";
@@ -201,7 +211,7 @@ namespace Raspberry
                             suffix = "." + val;
 
                         settings.Add(key + suffix, val);
-                        Console.WriteLine("setting.add = " + key + " + " + suffix + ", " + val);
+                        ///Console.WriteLine("setting.add = " + key + " + " + suffix + ", " + val);
                     }
                     else
                         suffix = "";
@@ -217,6 +227,7 @@ namespace Raspberry
 
         private Model LoadModel()
         {
+            Console.WriteLine("Inside  Boards.cs Model LoadModel");
             var firmware = Firmware;
             Console.WriteLine("Firmware = {0:x}", firmware);
             Console.WriteLine("Firmware & 0xFFFF = {0:x}", firmware & 0xFFFF);
@@ -286,6 +297,7 @@ namespace Raspberry
 
         private ConnectorPinout LoadConnectorPinout()
         {
+            Console.WriteLine("Inside  Boards.cs ConnectorPinout LoadConnectorPinout");
             switch (Model)
             {
                 case Model.BRev1:

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -94,9 +94,11 @@ namespace Raspberry
                     {
                         processor = Processor.Bcm2711;
                     }
+                    Console.WriteLine(processor);
                     return processor;
                 }
 
+                Console.WriteLine("Processor.Unknown");
                 return  Processor.Unknown;
             }
         }
@@ -198,6 +200,7 @@ namespace Raspberry
                             suffix = "." + val;
 
                         settings.Add(key + suffix, val);
+                        Console.WriteLine("setting.add = " + key + " + " + suffix + ", " + val);
                     }
                     else
                         suffix = "";
@@ -214,10 +217,13 @@ namespace Raspberry
         private Model LoadModel()
         {
             var firmware = Firmware;
+            Console.WriteLine("Firmware = " + firmware);
+            
             switch (firmware & 0xFFFF)
             {
                 case 0x2:
                 case 0x3:
+                    Console.WriteLine("Model.BRev1");
                     return Model.BRev1;
 
                 case 0x4:
@@ -226,41 +232,52 @@ namespace Raspberry
                 case 0xd:
                 case 0xe:
                 case 0xf:
+                    Console.WriteLine("Model.BRev2");
                     return Model.BRev2;
 
                 case 0x7:
                 case 0x8:
                 case 0x9:
+                    Console.WriteLine("Model.A");
                     return Model.A;
 
                 case 0x10:
+                    Console.WriteLine("Model.BPlus1");
                     return Model.BPlus;
 
                 case 0x11:
+                    Console.WriteLine("Model.ComputeModule");
                     return Model.ComputeModule;
 
                 case 0x12:
+                    Console.WriteLine("Model.APlus");
                     return Model.APlus;
 
                 case 0x1040:
                 case 0x1041:
+                    Console.WriteLine("Model.B2");
                     return Model.B2;
 
                 case 0x0092:
                 case 0x0093:
+                    Console.WriteLine("Model.Zero");
                     return Model.Zero;
 
                 case 0x2082:
+                    Console.WriteLine("Model.B3");
                     return Model.B3;
                 case 0x20A0:
+                    Console.WriteLine("Model.ComputeModule3");
                     return Model.ComputeModule3;
 
                 case 0x03111:
                 case 0x03112:
                 case 0x03114:
+                    Console.WriteLine("Model.Pi4");
                     return Model.Pi4;
 
                 default:
+                    Console.WriteLine("Model.Unknown");
                     return Model.Unknown;
             }
         }
@@ -270,10 +287,12 @@ namespace Raspberry
             switch (Model)
             {
                 case Model.BRev1:
+                    Console.WriteLine("ConnectorPinout.Rev1");
                     return ConnectorPinout.Rev1;
 
                 case Model.BRev2:
                 case Model.A:
+                    Console.WriteLine("ConnectorPinout.Rev2");
                     return ConnectorPinout.Rev2;
 
                 case Model.BPlus:
@@ -284,9 +303,11 @@ namespace Raspberry
                 case Model.B3:
                 case Model.ComputeModule3:
                 case Model.Pi4:
+                    Console.WriteLine("ConnectorPinout.Plus");
                     return ConnectorPinout.Plus;
 
                 default:
+                    Console.WriteLine("ConnectorPinout.Unknown");
                     return ConnectorPinout.Unknown;
             }
         }

--- a/Raspberry.System/Board.cs
+++ b/Raspberry.System/Board.cs
@@ -218,6 +218,7 @@ namespace Raspberry
         {
             var firmware = Firmware;
             Console.WriteLine("Firmware = " + firmware);
+            Console.WriteLine("Firmware & 0xFFFF = " + firmware & 0xFFFF);
             
             switch (firmware & 0xFFFF)
             {

--- a/Raspberry.System/Processor.cs
+++ b/Raspberry.System/Processor.cs
@@ -29,15 +29,5 @@ namespace Raspberry
         /// Processor is BCM2835 (BCM2708).
         /// </summary>
         Bcm2835,
-
-        /// <summary>
-        /// Processor is BCM2836 (BCM2709).
-        /// </summary>
-        Bcm2836,
-
-        /// <summary>
-        /// Processor is BCM2837 (BCM2710).
-        /// </summary>
-        Bcm2837
     }
 }

--- a/Raspberry.System/Processor.cs
+++ b/Raspberry.System/Processor.cs
@@ -21,11 +21,6 @@ namespace Raspberry
         Bcm2709,
 
         /// <summary>
-        /// Processor is BCM2710 (BCM2837)
-        /// </summary>
-        Bcm2710,
-
-        /// <summary>
         /// Processor is BCM2711
         /// </summary>
         Bcm2711,

--- a/Raspberry.System/Processor.cs
+++ b/Raspberry.System/Processor.cs
@@ -11,14 +11,19 @@ namespace Raspberry
         Unknown,
 
         /// <summary>
-        /// Processor is a BCM2708.
+        /// Processor is a BCM2708 (BCM2835).
         /// </summary>
         Bcm2708,
 
         /// <summary>
-        /// Processor is a BCM2709.
+        /// Processor is a BCM2709 (BCM2836).
         /// </summary>
         Bcm2709,
+
+        /// <summary>
+        /// Processor is BCM2710 (BCM2837)
+        /// </summary>
+        Bcm2710,
 
         /// <summary>
         /// Processor is BCM2711
@@ -26,8 +31,18 @@ namespace Raspberry
         Bcm2711,
 
         /// <summary>
-        /// Processor is BCM2835
+        /// Processor is BCM2835 (BCM2708).
         /// </summary>
-        Bcm2835
+        Bcm2835,
+
+        /// <summary>
+        /// Processor is BCM2836 (BCM2709).
+        /// </summary>
+        Bcm2836,
+
+        /// <summary>
+        /// Processor is BCM2837 (BCM2710).
+        /// </summary>
+        Bcm2837
     }
 }

--- a/Raspberry.System/Processor.cs
+++ b/Raspberry.System/Processor.cs
@@ -11,12 +11,12 @@ namespace Raspberry
         Unknown,
 
         /// <summary>
-        /// Processor is a BCM2708 (BCM2835).
+        /// Processor is a BCM2708
         /// </summary>
         Bcm2708,
 
         /// <summary>
-        /// Processor is a BCM2709 (BCM2836).
+        /// Processor is a BCM2709
         /// </summary>
         Bcm2709,
 
@@ -26,8 +26,8 @@ namespace Raspberry
         Bcm2711,
 
         /// <summary>
-        /// Processor is BCM2835 (BCM2708).
+        /// Processor is BCM2835
         /// </summary>
-        Bcm2835,
+        Bcm2835
     }
 }

--- a/Test.Board/Program.cs
+++ b/Test.Board/Program.cs
@@ -7,6 +7,7 @@ namespace Test.Board
     {
         static void Main()
         {
+            Console.WriteLine("Inside Test.Board Main");
             var board = Raspberry.Board.Current;
 
             if (!board.IsRaspberryPi)

--- a/Test.Board/Program.cs
+++ b/Test.Board/Program.cs
@@ -7,7 +7,6 @@ namespace Test.Board
     {
         static void Main()
         {
-            ///Console.WriteLine("Inside Test.Board Main");
             var board = Raspberry.Board.Current;
 
             if (!board.IsRaspberryPi)

--- a/Test.Board/Program.cs
+++ b/Test.Board/Program.cs
@@ -7,7 +7,7 @@ namespace Test.Board
     {
         static void Main()
         {
-            Console.WriteLine("Inside Test.Board Main");
+            ///Console.WriteLine("Inside Test.Board Main");
             var board = Raspberry.Board.Current;
 
             if (!board.IsRaspberryPi)


### PR DESCRIPTION
This update will cause the raspberry-sharp-system library to report the correct chip rather than relying on the OS reported processor.  Since Raspbian Jessie the CPU has been reported as BCM2835 regardless of actual hardware.  As a result, the update in June 2020 was required.  However, this update only addressed RPi4 and all other boards would not function.  This update extends the same approach to correctly report the CPU.

Note that this update reports the CPU for RPi3 as BCM2709 rather than BCM2710.  Since both use the same address for GPIO and the BCM2710 is not included in the raspberry-sharp-io library, this is a slight hack to remain compatible.  If that library were updated to include the BCM2710 hardware, the code in this library should be updated.